### PR TITLE
Onboard the permanent version of flusight_hub_archive to AWS

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -14,4 +14,6 @@ hubs:
 - hub: temp-flusight-archive-hub
   org: hubverse-org
   repo: flusight1_hub
-
+- hub: flusight-hub-archive
+  org: hubverse-org
+  repo: flusight_hub_archive

--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -14,6 +14,6 @@ hubs:
 - hub: temp-flusight-archive-hub
   org: hubverse-org
   repo: flusight1_hub
-- hub: flusight-hub-archive
+- hub: uscdc-flusight-hub-v1
   org: hubverse-org
   repo: flusight_hub_archive


### PR DESCRIPTION
This PR provisions AWS resources for the permanent version of the FluSight archives.