### PR TITLE
Remove temp-flusight-archive-hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -11,9 +11,6 @@ hubs:
 - hub: cdcepi-flusight-forecast-hub
   org: cdcepi
   repo: FluSight-forecast-hub
-- hub: temp-flusight-archive-hub
-  org: hubverse-org
-  repo: flusight1_hub
 - hub: uscdc-flusight-hub-v1
   org: hubverse-org
   repo: flusight_hub_archive


### PR DESCRIPTION
Now that uscdc-flusight-hub-v1 is online, we no longer need the temporary version. 

Note that the contents of the S3 bucket have been manually deleted (otherwise, the "delete bucket" operation will fail)