### PR TITLE
Onboard example-complex-forecast-hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -14,3 +14,6 @@ hubs:
 - hub: uscdc-flusight-hub-v1
   org: hubverse-org
   repo: flusight_hub_archive
+- hub: example-complex-forecast-hub
+  org: hubverse-org
+  repo: example-complex-forecast-hub


### PR DESCRIPTION
We had this hub in the cloud during the early testing days, and now it's time to onboard it using the current version of admin.json and the hubverse-aws-upload GitHub workflow.