### PR TITLE
Add a CORS configuration to hubverse S3-buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The IAM roles below are used by Pulumi, thus they are not managed by Pulumi. Ins
 
 If you're a Hubverse developer who wants to use Pulumi locally (using [Pulumi's CLI](https://www.pulumi.com/docs/cli/), for example), you will need access to AWS credentials with the same permissions used by the GitHub workflows.
 
+**Note:** if you're adding a new type of AWS resource and get a 403 error from the `pulumi_update` GitHub action (or when running `pulumi up` manually), you likely need to update the `hubverse-infrastructure-write-policy` (which is attached to `hubverse-infrastructure-write-role`) to ensure it has permissions to create the new resource.
+
 ### Setup instructions
 
 1. Make sure you have the required version on Python installed on your machine (see [`.python-version`](.python-version)).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,20 @@ The IAM roles below are used by Pulumi, thus they are not managed by Pulumi. Ins
 
 If you're a Hubverse developer who wants to use Pulumi locally (using [Pulumi's CLI](https://www.pulumi.com/docs/cli/), for example), you will need access to AWS credentials with the same permissions used by the GitHub workflows.
 
-**Note:** if you're adding a new type of AWS resource and get a 403 error from the `pulumi_update` GitHub action (or when running `pulumi up` manually), you likely need to update the `hubverse-infrastructure-write-policy` (which is attached to `hubverse-infrastructure-write-role`) to ensure it has permissions to create the new resource.
+### Updating permissions used by Pulumi
+
+If you get a 403 error from the `pulumi_update` GitHub action (or when running `pulumi up` manually), it's likely the Pulumi code is trying to make a change that the AWS IAM `hubverse-infrastructure-write-role` role doesn't have permission to make.
+
+`hubverse-infrastructure-write-role` is attached to an IAM policy that describes what it's allowed to do: `hubverse-infrastructure-write-policy`. Thus, to grant additional permissions required for Pulumi operations, you will need to update `hubverse-infrastructure-write-policy` via the AWS console:
+
+1. Log in to the AWS console.
+2. Click on _Services_ in the top left corner, and then click on _IAM_.
+3. From the _IAM_ dashboard, find the _Access management_ section in the left-hand menu and click on _Policies_.
+4. When the list of policies appears, use the search box to find `hubverse-infrastructure-write-policy` and click on it.
+5. Click the _Edit_ button to update the policy.
+
+**Note:** To make these changes, you will need to have a Hubverse AWS login with console permission and with policy update permissions.
+
 
 ### Setup instructions
 

--- a/src/hubverse_infrastructure/hubs/s3.py
+++ b/src/hubverse_infrastructure/hubs/s3.py
@@ -68,7 +68,7 @@ def make_bucket_public(bucket: aws.s3.Bucket, bucket_name: str):
 
 def add_s3_cors_config(bucket: aws.s3.Bucket, bucket_name: str):
     """
-    Add CORS configuration to a spciified S3 bucket.
+    Add CORS configuration to a specified S3 bucket.
     Having a CORS policy allows S3 buckets to be accessed via HTTP requests.
     """
 

--- a/src/hubverse_infrastructure/hubs/s3.py
+++ b/src/hubverse_infrastructure/hubs/s3.py
@@ -66,8 +66,33 @@ def make_bucket_public(bucket: aws.s3.Bucket, bucket_name: str):
     )
 
 
+def add_s3_cors_config(bucket: aws.s3.Bucket, bucket_name: str):
+    """
+    Add CORS configuration to a spciified S3 bucket.
+    Having a CORS policy allows S3 buckets to be accessed via HTTP requests.
+    """
+
+    aws.s3.BucketCorsConfigurationV2(
+        resource_name=f"{bucket_name}-bucket-cors-config",
+        bucket=bucket.id,
+        cors_rules=[
+            {
+                "allowed_headers": ["*"],
+                "allowed_methods": [
+                    "GET",
+                    "HEAD",
+                ],
+                "allowed_origins": ["*"],
+                "expose_headers": [],
+                "max_age_seconds": 3000,
+            }
+        ],
+    )
+
+
 def create_s3_infrastructure(hub_info: dict) -> aws.s3.Bucket:
     hub_name = hub_info["hub"]
     bucket = create_bucket(hub_name)
     make_bucket_public(bucket, hub_name)
+    add_s3_cors_config(bucket, hub_name)
     return bucket


### PR DESCRIPTION
Resolves #48

To ensure that the "publicly accessible" component of Hubverse S3 buckets extends to web/HTTP requests, each bucket requires a CORS configuration. The configuration defined in this PR matches the one that @elray1 and I tested during the June, 2024 Hubverse retreat:

```json
[
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "GET",
            "HEAD"
        ],
        "AllowedOrigins": [
            "*"
        ],
        "ExposeHeaders": [],
        "MaxAgeSeconds": 3000
    }
]
```

In addition to the code changes, I manually updated the AWS IAM policy used by the `pulumi_update.yaml` GitHub action to ensure that it has permission to update CORS policies:

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/3284e96e-16a7-445f-a326-b9f5b2f4ef51">