### PR TITLE
Add covid-clade-counts

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -20,3 +20,8 @@ hubs:
 - hub: example-complex-forecast-hub
   org: hubverse-org
   repo: example-complex-forecast-hub
+# special case: covid-clade-counts is not hub
+- hub: covid-clade-counts
+  org: reichlab
+  repo: covid-clade-counts
+


### PR DESCRIPTION
Covid-clade-counts isn't a hub, but we're onboarding it as such so that repo can push files to an S3 bucket via the GitHub action/OIDC we have set up in the Hubverse AWS