### PR TITLE
Create AWS infrastructure for hosting variant-nowcast-hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -20,3 +20,6 @@ hubs:
 - hub: example-complex-forecast-hub
   org: hubverse-org
   repo: example-complex-forecast-hub
+- hub: covid-variant-nowcast-hub
+  org: reichlab
+  repo: variant-nowcast-hub


### PR DESCRIPTION
We briefly discussed the S3 bucket name ("hub" in the hubs.yaml file) here:
https://reichlab.slack.com/archives/C06ESFN6Y79/p1731532728001529

I added the `-hub` suffix to our agreed-upon name for consistency with other hubs we're hosting on AWS but can remove that if people object.