### PR TITLE
Increase memory and timeout configuration for the transform lambda

### DIFF
--- a/src/hubverse_infrastructure/shared/hubverse_transforms.py
+++ b/src/hubverse_infrastructure/shared/hubverse_transforms.py
@@ -169,7 +169,8 @@ def create_transform_lambda(
         s3_bucket=s3_bucket,
         s3_key=s3_key,
         tags={"hub": "hubverse"},
-        timeout=210,
+        memory_size=500,
+        timeout=600,
         opts=ResourceOptions(depends_on=[hubverse_asset_bucket]),
     )
 


### PR DESCRIPTION
Addresses https://github.com/hubverse-org/hubverse-transform/issues/32

We started seeing out of memory errors in the transform lambda when onboarding the variant-nowcast-hub. This is the first time we've onboarded a hub to S3 that includes sample data, and the default memory allocation of 128MB isn't sufficient.

For example, a single UMass submission is 27MB in memory after the parquet file is read by pyarrow. We can and should investigate ways to make the transform process better about memory, but let's increase the memory now to ensure we're in a good place until then.