### PR TITLE
Provide explicit ids for s3BucketNotificationLambdaFunctionArgs and cors_rules

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -39,5 +39,6 @@ jobs:
           command: preview
           stack-name: hubverse/hubverse-aws/hubverse
           comment-on-pr: true
+          diff: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEMO }}

--- a/.github/workflows/pulumi_update.yaml
+++ b/.github/workflows/pulumi_update.yaml
@@ -38,5 +38,6 @@ jobs:
           command: up
           stack-name: hubverse/hubverse-aws/hubverse
           comment-on-pr: true
+          diff: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.BSWEGER_PULUMI_DEMO }}

--- a/src/hubverse_infrastructure/hubs/iam.py
+++ b/src/hubverse_infrastructure/hubs/iam.py
@@ -120,6 +120,7 @@ def create_model_output_lambda_trigger(
         bucket=hub_bucket.id,
         lambda_functions=[
             aws.s3.BucketNotificationLambdaFunctionArgs(
+                id=f"{hub_name}-notification-args",
                 lambda_function_arn=model_output_lambda.arn.apply(lambda arn: f"{arn}"),
                 events=["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
                 filter_prefix="raw/",

--- a/src/hubverse_infrastructure/hubs/s3.py
+++ b/src/hubverse_infrastructure/hubs/s3.py
@@ -77,6 +77,7 @@ def add_s3_cors_config(bucket: aws.s3.Bucket, bucket_name: str):
         bucket=bucket.id,
         cors_rules=[
             {
+                "id": f"{bucket_name}-cors-rules",
                 "allowed_headers": ["*"],
                 "allowed_methods": [
                     "GET",


### PR DESCRIPTION
When opening the [PR to address some security issues](https://github.com/hubverse-org/hubverse-infrastructure/pull/67), I ran into two vexing things:

1. The Pulumi diff in the PR flagged that we're adding an `objectRemoved` trigger to six of our seven hub buckets. The triggers were, in fact, applied to the S3 buckets, but for 6 out of 7 hubs, that addition was not recorded in [Pulumi's state information](https://app.pulumi.com/hubverse/hubverse-aws/hubverse/resources). Thus, the `pulumi preview` workflow flags those 6 hubs as getting an update.

2. When I ran `pulumi refresh` on my machine, it showed that our `cores_rules` resources between AWS and Pulumi's state are not in sync. The only difference I could find was an empty `id` field in Pulumi's state and no `id` field in AWS. This PR adds an `id` in our Pulumi code, which will hopefully prevent this diff in the future.

I'm not sure this PR will fix item 1, but I'm hoping that adding an explicit resource id to the `s3BucketNotificationLambdaFunctionArgs` will make for easier debugging.