### PR TITLE
Enable versioning on Hubverse buckets

### DIFF
--- a/src/hubverse_infrastructure/hubs/s3.py
+++ b/src/hubverse_infrastructure/hubs/s3.py
@@ -8,7 +8,12 @@ def create_bucket(hub_name: str) -> aws.s3.Bucket:
     (for simplicity, in this demo we're setting the bucket name to the hub name)
     """
 
-    hub_bucket = aws.s3.Bucket(hub_name, bucket=hub_name, tags={"hub": hub_name})
+    hub_bucket = aws.s3.Bucket(
+        hub_name,
+        bucket=hub_name,
+        tags={"hub": hub_name},
+        versioning={"enabled": True},
+    )
 
     return hub_bucket
 


### PR DESCRIPTION
Closes #52 

This change will ensure that new buckets created will have versioning enabled. For our existing Hubverse-hosted hubs, existing files will not be versioned (i.e., version id will be NULL). New files will be versioned as they arrive.

More information: https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html

Notes:
- hubs/hubs.yaml lists 7 hubs, but one of our test hub buckets already had versioning enabled, so the diff on this PR should show 6 buckets being updated
- we were originally unsure about the cost of versioning (you pay for multiple copies of the same object), but:
    - The Hubverse AWS bills are very low (our last one was .08)
    - The largest portion of data are model output files, which we don't expect to have multiple versions
- the [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html) say to wait 15 minutes after making change to start writing data again (i.e., maybe don't merge this on a hub submission day)