### PR TITLE
Add a hub for testing an updated trust policy for Pulumi OIDC

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -23,3 +23,7 @@ hubs:
 - hub: covid-variant-nowcast-hub
   org: reichlab
   repo: variant-nowcast-hub
+- hub: fancy-oidc-hub
+  org: reichlab
+  repo: fancy-oidc-hub
+


### PR DESCRIPTION
This PR will provision AWS resources for a new test hub.

The hub doesn't actually exist, and once we confirm that the AWS trust policy for the Pulumi OIDC provider is working, we'll submit another PR to remove there resources.