### PR TITLE
Update Python setup instructions

### DIFF
--- a/.test-data/howdy.txt
+++ b/.test-data/howdy.txt
@@ -1,1 +1,0 @@
-This is a file to test syncing data from github to S3.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to hubverse-infrastructure
+
+This document covers how to propose a change to `hubverse-infrastructure` and how to set up the project
+for development on your local machine.
+
+This is an internal Hubverse package used to manage cloud infrastructure, so these directions are intended
+for the Hubverse development team.
+
+For general info about contributing to Hubverse packages, please see the
+[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+
+## Onboarding a hub
+
+> [!TIP]
+> You do not need to set up a `hubverse-infrastructure` local development
+> environment to provision S3 resource for a new hub.
+
+Provisioning AWS resources for a new hub requires adding a few lines to
+[`hubs.yaml`](src/hubverse_infrastructure/hubs/hubs.yaml). Thus, Hubverse developers can onboard a new hub by
+using the GitHub UI to modify `hubs.yaml` as described in [README.md](README.md#onboarding-a-hub).
+
+## Local development setup
+
+This project uses [`uv`](https://docs.astral.sh/uv/) to manage Python installs,
+dependencies, and virtual environments. The result is less work to set up
+a development environment.
+
+However, contributors who prefer different Python tools can still use them as
+long as dependency updates follow the workflow of adding (or removing)
+dependencies from `pyproject.toml` and re-generating an annotated
+`requirements/requirements.txt` file. In other words, don't update
+the requirements.txt file directly.
+
+> [!IMPORTANT]
+> If you have an active Python virtual environment (for example, conda's
+> base environment), you'll need to deactivate it before following the
+> instructions below.
+> See the hubDocs wiki for further
+> [troubleshooting information](https://github.com/hubverse-org/hubDocs/wiki/Troubleshooting).
+
+1. Install uv on your machine (you will only need to do this once):
+<https://docs.astral.sh/uv/getting-started/installation/>
+2. The rest of the instructions should be executed from the cloned repository's root directory
+(*e.g.*, `/Users/hubUser/repositories/hubverse-infrastructure`).
+3. Create a virtual environment for the project:
+
+    ```bash
+    uv venv --seed
+    ```
+
+    > [!NOTE]
+    > The output of this command provides an instruction for activating the new
+    > virtual environment. Doing so is optional, as subsequent `uv` commands
+    > will detect and use the environment automatically.
+
+4. Install dependencies (including install the package in editable mode):
+
+    ```bash
+    uv pip install -r requirements/requirements.txt
+    uv pip install -e .
+    ```
+
+5. Run the tests to ensure that everything is working:
+
+    ```bash
+    uv run pytest
+    ```
+
+Once you've confirmed that the project is set up correctly, make your changes and follow the Hubverse's
+[Python development workflow](https://hubverse.io/en/latest/developer/python.html).
+
+### Adding, updating, or removing project dependencies
+
+If you need to update a hubverse-infrastructure dependency:
+
+1. Add, change, or delete the dependency in the project config (`pyproject.toml`):
+
+    ```bash
+    uv add <name of package>
+    ```
+
+    or
+
+    ```bash
+    uv add <name of package> --upgrade
+    ```
+    or
+
+    ```bash
+    uv remove <name of package >
+    ```
+
+2. Generate updated requirements files:
+
+    ```script
+    uv pip compile pyproject.toml -o requirements/requirements.txt
+    uv pip compile pyproject.toml --extra dev -o requirements/dev-requirements.txt
+    ```
+
+3. Install the updated requirements into your development environment:
+
+    ```script
+    uv pip install -r requirements/dev-requirements.txt
+    ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The GitHub app initiates a deployment process when:
 - A PR is merged into the `main` branch (for applying changes)
 
 These deployments are configured to use the Pulumi OIDC identity provider created in our Hubverse AWS account. The OIDC
-provider allows Pulumi to request temporary AWS credentials and assume the following AWS role when peforming previews
+provider allows Pulumi to request temporary AWS credentials and assume the following AWS role when performing previews
 and updates:
 
 - `hubverse-infrastructure-write-role`
@@ -205,49 +205,6 @@ required for Pulumi operations, you will need to update `hubverse-infrastructure
 > - console permission
 > - policy update permissions
 
-### Setup instructions
+## Local development
 
-1. Make sure you have the required version on Python installed on your machine (see [`.python-version`](.python-version)).
-
-    **note:** [pyenv](https://github.com/pyenv/pyenv) is a good tool for managing multiple version of Python on a single machine.
-
-2. Clone this repository and navigate to the project directory.
-
-3. Make sure your machine's current Python interpreter is set to the project's required version of Python, and then create a virtual environment. You can use any third-party tool that manages Python environments (e.g., pipenv, poetry), or you can use Python's built-in `venv` module (make sure you're at the top of the project directory):
-    ```bash
-    python -m venv .venv
-    ```
-
-4. Activate the virtual environment. If you created the environment using the `venv` command above, you can activate it as follows:
-    ```bash
-    source .venv/bin/activate
-    ```
-
-5. Install the project's dependencies:
-    ```bash
-    pip install -r requirements/dev-requirements.txt && pip install -e .
-    ```
-
-
-### Adding dependencies
-
-This project uses `pip-tools` to generate requirements files from `pyproject.toml`.  To add new dependencies, you will need to install [`pip-tools`](https://pip-tools.readthedocs.io/en/latest/) into your virtual environment (or use [`pipx`](https://github.com/pypa/pipx) to make it available on your machine globally).
-
-To add a new dependency:
-
-1. Add dependency to the `dependencies` section `pyproject.toml` (if it's a dev dependency, add it to the `dev` section of `[project.optional-dependencies]`).
-
-2. Regenerate the `requirements.txt` file (you can skip this if you've only added a dev dependency):
-    ```bash
-    pip-compile --output-file=requirements/requirements.txt pyproject.toml
-    ```
-
-3. Regenerate the `requirements-dev.txt` file (you will need to do this every time, even if you haven't added a dev dependency):
-    ```bash
-    pip-compile --extra=dev --output-file=requirements/dev-requirements.txt pyproject.toml
-    ```
-
-4. Install the updated dependencies into your virtual environment:
-    ```bash
-    pip install -r requirements/dev-requirements.txt
-    ```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on setting up a local development environment.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ Each cloud-enabled hub requires several dedicated AWS resources. These resources
       of the hub's repository.
     - A _permission policy_ that grants write access to the hub's S3 bucket.
 
-## Onboarding a hub
+## Onboarding a hub to AWS
 
 Other than the ability to submit a PR to this repository, no special permissions are required for onboarding a hub to
 the Hubverse AWS account.
+
+Note that these instructions are for provisioning a hub's AWS resources.
+There are a few other steps to fully onboard a hub to the cloud. Please
+see the [Hubverse documentation](https://hubverse.io/en/latest/) for a complete guide.
 
 To begin syncing an existing Hubverse hub to S3:
 


### PR DESCRIPTION
Closes #78 

This PR simplifies the Python setup instructions by incorporating the uv-based process we tested for [hubDocs](https://github.com/hubverse-org/hubDocs/blob/main/README.md#local-development).

Additionally, it moves the setup directions to CONTRIBUTING.md.