### PR TITLE
Create AWS resources for flu metrocast hub

### DIFF
--- a/src/hubverse_infrastructure/hubs/hubs.yaml
+++ b/src/hubverse_infrastructure/hubs/hubs.yaml
@@ -23,3 +23,6 @@ hubs:
 - hub: covid-variant-nowcast-hub
   org: reichlab
   repo: variant-nowcast-hub
+- hub: reichlab-flu-metrocast-hub
+  org: reichlab
+  repo: flu-metrocast


### PR DESCRIPTION
This is another test (after uninstalling the Pulumi GitHub app and then re-installing it)