### PR TITLE
Tell dependabot to consolidate minor dependency updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# instruct GitHub dependabot to scan github actions and python code for dependency updates
+# instruct GitHub dependabot to scan github actions and Python code for dependency updates
 
 version: 2
 updates:
@@ -7,8 +7,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
 
   - package-ecosystem: "pip"
-    directory: "/requirements/"
+    directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      py-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
To reduce the amount of "noise" from Dependabot-submitted pull requests, this changeset adds a "groups" setting to dependabot.yaml. More information about the groups setting: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

The changeset also changes the "pip" package-ecosystem directory from "requirements" to the repo's root, where pyproject.toml is located.