### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This is an internal Hubverse package used to manage cloud infrastructure, so the
 for the Hubverse development team.
 
 For general info about contributing to Hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 ## Onboarding a hub
 
@@ -67,7 +67,7 @@ the requirements.txt file directly.
     ```
 
 Once you've confirmed that the project is set up correctly, make your changes and follow the Hubverse's
-[Python development workflow](https://hubverse.io/en/latest/developer/python.html).
+[Python development workflow](https://docs.hubverse.io/en/latest/developer/python.html).
 
 ### Adding, updating, or removing project dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://www.pulumi.com/images/pricing/team-oss.svg" alt="Pulumi Team edition for open source" style="width:100px; float: left; margin-right: 10px;"/>
 
 This repository uses [Pulumi](https://www.pulumi.com/) to provision cloud resources for the Hubverse, a project that
-provides open tools for collaborative modeling: [https://hubverse.io/en/latest/](https://hubverse.io/en/latest/).
+provides open tools for collaborative modeling: [https://docs.hubverse.io/en/latest/](https://docs.hubverse.io/en/latest/).
 
 ## Background
 
@@ -57,7 +57,7 @@ the Hubverse AWS account.
 
 Note that these instructions are for provisioning a hub's AWS resources.
 There are a few other steps to fully onboard a hub to the cloud. Please
-see the [Hubverse documentation](https://hubverse.io/en/latest/) for a complete guide.
+see the [Hubverse documentation](https://docs.hubverse.io/en/latest/) for a complete guide.
 
 To begin syncing an existing Hubverse hub to S3:
 


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.